### PR TITLE
Fix maven reference

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -25,7 +25,7 @@ elif [ $(uname) = "Darwin" ]; then
 fi
 
 readonly MAVEN_REPO="${HOME}/.m2"
-readonly MAVEN_URL="https://dlcdn.apache.org/maven/maven-3/3.9.2/binaries/apache-maven-3.9.2-bin.tar.gz"
+readonly MAVEN_URL="https://dlcdn.apache.org/maven/maven-3/3.9.3/binaries/apache-maven-3.9.3-bin.tar.gz"
 readonly MAVEN_ARCHIVE=$(basename ${MAVEN_URL})
 readonly MAVEN_DIRECTORY=$(basename -s -bin.tar.gz ${MAVEN_URL})
 readonly MAVEN_TMP_PATH="/var/tmp/${MAVEN_ARCHIVE}"


### PR DESCRIPTION
`run.sh` would not run without this change. The previous url gave a 404. 