### PR TITLE
Pin versions of dependencies

### DIFF
--- a/lib/lx/pom.xml
+++ b/lib/lx/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>heronarts.lx</groupId>
     <artifactId>lx</artifactId>
-    <version>HEAD</version>
+    <version>1.0.0</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -50,7 +50,7 @@
                     <archive>
                         <manifestEntries>
                             <Implementation-Title>lx</Implementation-Title>
-                            <Implementation-Version>HEAD</Implementation-Version>
+                            <Implementation-Version>1.0.0</Implementation-Version>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/lib/p3lx/pom.xml
+++ b/lib/p3lx/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.github.micycle1</groupId>
             <artifactId>processing-core-4</artifactId>
-            <version>d33cae501e</version>
+            <version>4.3.3</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/lib/p3lx/pom.xml
+++ b/lib/p3lx/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>heronarts.p3lx</groupId>
     <artifactId>p3lx</artifactId>
-    <version>HEAD</version>
+    <version>0.2.3</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>heronarts.lx</groupId>
             <artifactId>lx</artifactId>
-            <version>HEAD</version>
+            <version>1.0.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.processing</groupId>
             <artifactId>video</artifactId>
-            <version>HEAD</version>
+            <version>3.3.7</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>
@@ -78,7 +78,7 @@
                     <archive>
                         <manifestEntries>
                             <Implementation-Title>p3lx</Implementation-Title>
-                            <Implementation-Version>HEAD</Implementation-Version>
+                            <Implementation-Version>0.2.3</Implementation-Version>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/lib/processing-video/pom.xml
+++ b/lib/processing-video/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.github.micycle1</groupId>
             <artifactId>processing-core-4</artifactId>
-            <version>d33cae501e</version>
+            <version>4.3.3</version>
             <scope>compile</scope>
         </dependency>
 

--- a/lib/processing-video/pom.xml
+++ b/lib/processing-video/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.processing</groupId>
     <artifactId>video</artifactId>
-    <version>HEAD</version>
+    <version>3.3.7</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -60,7 +60,7 @@
                     <archive>
                         <manifestEntries>
                             <Implementation-Title>org.processing.video</Implementation-Title>
-                            <Implementation-Version>HEAD</Implementation-Version>
+                            <Implementation-Version>3.3.7</Implementation-Version>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -35,13 +35,13 @@
         <dependency>
             <groupId>heronarts.lx</groupId>
             <artifactId>lx</artifactId>
-            <version>HEAD</version>
+            <version>1.0.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>heronarts.p3lx</groupId>
             <artifactId>p3lx</artifactId>
-            <version>HEAD</version>
+            <version>0.2.3</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.github.micycle1</groupId>
             <artifactId>processing-core-4</artifactId>
-            <version>d33cae501e</version>
+            <version>4.3.3</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/run.sh
+++ b/run.sh
@@ -25,7 +25,7 @@ elif [ $(uname) = "Darwin" ]; then
 fi
 
 readonly MAVEN_REPO="${HOME}/.m2"
-readonly MAVEN_URL="https://dlcdn.apache.org/maven/maven-3/3.9.4/binaries/apache-maven-3.9.4-bin.tar.gz"
+readonly MAVEN_URL="https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz"
 readonly MAVEN_ARCHIVE=$(basename ${MAVEN_URL})
 readonly MAVEN_DIRECTORY=$(basename -s -bin.tar.gz ${MAVEN_URL})
 readonly MAVEN_TMP_PATH="/var/tmp/${MAVEN_ARCHIVE}"
@@ -60,6 +60,8 @@ if [ ! -d lib/lx/git_submodule/src ]; then
 fi
 
 function build_subproject() {
+	echo "=== BUILD $2 ==="
+	echo "${MAVEN} dependency:get -Dartifact=$1 -o -DrepoUrl=file://${MAVEN_REPO}"
 	if "${MAVEN}" dependency:get -Dartifact=$1 -o -DrepoUrl=file://${MAVEN_REPO} > /dev/null; then
 		echo "$1 already in maven repo."
 	else
@@ -69,7 +71,9 @@ function build_subproject() {
 	fi
 }
 
+
 function install_jdk() {
+	echo "=== INSTALL_JDK ==="
 	if [ $(uname) = "Linux" ] && [ $(uname -m) =  "x86_64" ]; then
 		if [ -e "${JAVA_HOME}/bin/javac" ]; then
 			echo "Using JDK at ${JAVA_HOME}"
@@ -107,7 +111,9 @@ function install_jdk() {
 }
 
 function install_maven() {
+	echo "=== INSTALL_MAVEN ==="
 	if [ ! -e "${MAVEN}" ]; then
+		echo "installing..."
 		wget -nc -O "${MAVEN_TMP_PATH}" "${MAVEN_URL}"
 		tar -xf "${MAVEN_TMP_PATH}"
 	fi
@@ -117,13 +123,17 @@ if [ "$1" != "--fast" ]; then
 	install_jdk
 	install_maven
 
-	build_subproject "heronarts.lx:lx:HEAD" "lib/lx"
-	build_subproject "org.processing:video:HEAD" "lib/processing-video"
-	build_subproject "heronarts.p3lx:p3lx:HEAD" "lib/p3lx"
+	build_subproject "heronarts.lx:lx:1.0.0" "lib/lx"
+	build_subproject "org.processing:video:3.3.7" "lib/processing-video"
+	build_subproject "heronarts.p3lx:p3lx:0.2.3" "lib/p3lx"
 	build_subproject "ddf:minim:v2.2.2" "lib/minim"
 else
 	shift
 fi
+
+echo "=== COMPILING ==="
+
+echo "${MAVEN} compile"
 
 "${MAVEN}" compile
 "${MAVEN}" exec:java -Dexec.args="$*"


### PR DESCRIPTION
First off, things don't seem to build anymore 😓 

Second, part of the problem seems to be we're using HEAD rather than specific versions of libraries, so dependencies can pull the rug out from under us. This pins to the current latest version.

Second... we might have hit the point in which not even Java wants to run:

```bash
java.lang.RuntimeException: java.lang.UnsupportedClassVersionError: javafx/util/Pair has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 61.0
    at processing.opengl.PSurfaceJOGL.lambda$initAnimator$2 (PSurfaceJOGL.java:430)
    at java.lang.Thread.run (Thread.java:833)
Caused by: java.lang.UnsupportedClassVersionError: javafx/util/Pair has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 61.0
    at java.lang.ClassLoader.defineClass1 (Native Method)
    at java.lang.ClassLoader.defineClass (ClassLoader.java:1012)
    at java.security.SecureClassLoader.defineClass (SecureClassLoader.java:150)
    at java.net.URLClassLoader.defineClass (URLClassLoader.java:524)
    at java.net.URLClassLoader$1.run (URLClassLoader.java:427)
    at java.net.URLClassLoader$1.run (URLClassLoader.java:421)
```