### PR TITLE
fix build on current OS X in 2025

### DIFF
--- a/lib/p3lx/pom.xml
+++ b/lib/p3lx/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.github.micycle1</groupId>
             <artifactId>processing-core-4</artifactId>
-            <version>d33cae501e</version>
+            <version>4.2.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/lib/processing-video/pom.xml
+++ b/lib/processing-video/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.github.micycle1</groupId>
             <artifactId>processing-core-4</artifactId>
-            <version>d33cae501e</version>
+            <version>4.2.1</version>
             <scope>compile</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.github.micycle1</groupId>
             <artifactId>processing-core-4</artifactId>
-            <version>d33cae501e</version>
+            <version>4.2.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/run.sh
+++ b/run.sh
@@ -25,7 +25,7 @@ elif [ $(uname) = "Darwin" ]; then
 fi
 
 readonly MAVEN_REPO="${HOME}/.m2"
-readonly MAVEN_URL="https://dlcdn.apache.org/maven/maven-3/3.9.4/binaries/apache-maven-3.9.4-bin.tar.gz"
+readonly MAVEN_URL="https://archive.apache.org/dist/maven/maven-3/3.9.4/binaries/apache-maven-3.9.4-bin.tar.gz"
 readonly MAVEN_ARCHIVE=$(basename ${MAVEN_URL})
 readonly MAVEN_DIRECTORY=$(basename -s -bin.tar.gz ${MAVEN_URL})
 readonly MAVEN_TMP_PATH="/var/tmp/${MAVEN_ARCHIVE}"


### PR DESCRIPTION
I tried to run blinky-dome on my OS X laptop but ran into a few problems:

1. The URL for downloading the version of Maven that we're using is no longer correct for this old version.
2. It wasn't able to fetch `processing-core-4` because apparently, the commit hash (`d33cae501e`) is no longer being accepted by Jitpack, only version numbers (such as `4.2.1`).

I fixed this by finding the correct URL for the download of the old Maven version, and by changing the POM to get `processing-core-4` by version number (using `4.2.1` because it seems to be the closest to the commit hash that we were previously fetching, rather than `4.4.4` which is the now-current version.)

With these changes it builds and runs and I at least see the LX interface and a blinkydome on my screen.

I know absolutely nothing about Java, so please know that when I say things like POM, Jitpack, and Maven, I do not know what these words mean, and I'm just guessing that this is the correct fix. But it seems like a pretty good guess (and it works for me at least).

Perhaps rather than this fix, we should be updating to more recent versions of Maven and `processing-core-4`. I'll leave that to more knowledgable people since I wouldn't know how to validate if such an upgrade had worked.